### PR TITLE
Compat

### DIFF
--- a/expected/01-basic.out
+++ b/expected/01-basic.out
@@ -309,7 +309,7 @@ SELECT 1 AS exp, * FROM dbms_errlog.queue_size();
 
 -- should fail complaining that reject_limit has been reached
 INSERT INTO t1 VALUES ('queue 11b');
-WARNING:  pg_dbms_errlog.reject_limit is reached, no further error is handled
+WARNING:  pg_dbms_errlog.reject_limit (1) is reached (queue_entries=1), no further error is handled
 ERROR:  invalid input syntax for type bigint: "queue 11b"
 LINE 1: INSERT INTO t1 VALUES ('queue 11b');
                                ^

--- a/expected/05-privileges.out
+++ b/expected/05-privileges.out
@@ -132,18 +132,20 @@ SELECT count(*) FROM dbms_errlog.register_errlog_tables ;
 ----
 -- Try error logging creation by non superuser role
 ----
-CREATE TABLE t2 (
+CREATE SCHEMA pel_u1;
+GRANT ALL ON SCHEMA pel_u1 TO pel_u1;
+CREATE TABLE pel_u1.t3 (
     id int NOT NULL
 );
-GRANT ALL ON t2 TO pel_u1;
+GRANT ALL ON pel_u1.t3 TO pel_u1;
 GRANT ALL ON dbms_errlog.register_errlog_tables TO pel_u1;
 SET SESSION AUTHORIZATION 'pel_u1';
 SET pg_dbms_errlog.synchronous = query;
 SET pg_dbms_errlog.query_tag TO 'daily_load4';
 SET pg_dbms_errlog.reject_limit TO 25;
 SET pg_dbms_errlog.enabled TO true;
--- Create the error log table for relation t2 as non superuser role
-CALL dbms_errlog.create_error_log('t2');
+-- Create the error log table for relation pel_u1.t3 as non superuser role
+CALL dbms_errlog.create_error_log('pel_u1.t3', 'pel_u1."ERR$_t3"');
 -- Verify that it have been registered
 SELECT count(*) FROM dbms_errlog.register_errlog_tables ;
  count 
@@ -154,30 +156,30 @@ SELECT count(*) FROM dbms_errlog.register_errlog_tables ;
 -- Start a transaction
 BEGIN;
 SAVEPOINT aze;
--- Insert will fail for NULL value and will be registered in ERR$_t2
-INSERT INTO t2 VALUES (NULL);
+-- Insert will fail for NULL value and will be registered in pel_u1.ERR$_t3
+INSERT INTO pel_u1.t3 VALUES (NULL);
 ROLLBACK TO aze;
 COMMIT;
 -- Show content of the error log table with test user.
 \x
-SELECT * FROM "ERR$_t2"
+SELECT * FROM pel_u1."ERR$_t3"
 ORDER BY "pg_err_number$" COLLATE "C", "pg_err_mesg$" COLLATE "C";
 -[ RECORD 1 ]--+---------------------------------------------------------------------------------------
 pg_err_number$ | 23502
-pg_err_mesg$   | null value in column "id" of relation "t2" violates not-null constraint
+pg_err_mesg$   | null value in column "id" of relation "t3" violates not-null constraint
 pg_err_optyp$  | I
 pg_err_tag$    | daily_load4
-pg_err_query$  | INSERT INTO t2 VALUES (NULL);
-pg_err_detail$ | ERROR:  23502: null value in column "id" of relation "t2" violates not-null constraint+
+pg_err_query$  | INSERT INTO pel_u1.t3 VALUES (NULL);
+pg_err_detail$ | ERROR:  23502: null value in column "id" of relation "t3" violates not-null constraint+
                | DETAIL:  Failing row contains (null).                                                 +
-               | STATEMENT:  INSERT INTO t2 VALUES (NULL);                                             +
+               | STATEMENT:  INSERT INTO pel_u1.t3 VALUES (NULL);                                      +
                | 
 
 \x
 -- cleanup
-DROP TABLE t2; -- will fail
-ERROR:  must be owner of table t2
-DROP TABLE "ERR$_t2"; -- will be dropped
+DROP TABLE pel_u1.t3; -- will fail
+ERROR:  must be owner of table t3
+DROP TABLE pel_u1."ERR$_t3"; -- will be dropped
 SELECT count(*) FROM dbms_errlog.register_errlog_tables ;
  count 
 -------
@@ -185,7 +187,8 @@ SELECT count(*) FROM dbms_errlog.register_errlog_tables ;
 (1 row)
 
 SET SESSION AUTHORIZATION DEFAULT;
-DROP TABLE t2;
+DROP TABLE pel_u1.t3;
+DROP SCHEMA pel_u1;
 SELECT count(*) FROM dbms_errlog.register_errlog_tables ;
  count 
 -------

--- a/pel_errqueue.c
+++ b/pel_errqueue.c
@@ -231,7 +231,7 @@ pel_prepare_entry(void)
 	if (pel_reject_limit > -1 &&
 			local_data.entry->num_entries >= pel_reject_limit )
 	{
-		elog(WARNING, "pg_dbms_errlog.reject_limit (%d) is reached (queue entries= %d), no further"
+		elog(WARNING, "pg_dbms_errlog.reject_limit (%d) is reached (queue_entries=%d), no further"
 					  " error is handled", pel_reject_limit, local_data.entry->num_entries);
 		pel_cleanup_local();
 		return false;

--- a/pg_dbms_errlog.c
+++ b/pg_dbms_errlog.c
@@ -160,7 +160,6 @@ struct HTAB *PreparedCache = NULL;
 
 /* Functions declaration */
 void        _PG_init(void);
-void        _PG_fini(void);
 
 extern PGDLLEXPORT Datum pg_dbms_errlog_publish_queue(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(pg_dbms_errlog_publish_queue);
@@ -444,23 +443,6 @@ _PG_init(void)
 	worker.bgw_main_arg = (Datum) 0;
 	worker.bgw_notify_pid = 0;
 	RegisterBackgroundWorker(&worker);
-}
-
-/*
- * Module unload callback
- */
-void
-_PG_fini(void)
-{
-	/* Uninstall hooks */
-	shmem_startup_hook = prev_shmem_startup_hook;
-	ProcessUtility_hook = prev_ProcessUtility;
-	ExecutorStart_hook = prev_ExecutorStart;
-	ExecutorRun_hook = prev_ExecutorRun;
-	ExecutorFinish_hook = prev_ExecutorFinish;
-	ExecutorEnd_hook = prev_ExecutorEnd;
-	emit_log_hook = prev_emit_log_hook;
-	post_parse_analyze_hook = prev_post_parse_analyze_hook;
 }
 
 PGDLLEXPORT Datum

--- a/pg_dbms_errlog.c
+++ b/pg_dbms_errlog.c
@@ -98,6 +98,9 @@ PG_MODULE_MAGIC;
 #define PEL_TRANCHE_NAME		"pg_dbms_errlog"
 
 /* Saved hook values in case of unload */
+#if PG_VERSION_NUM >= 150000
+static shmem_request_hook_type prev_shmem_request_hook = NULL;
+#endif
 static shmem_startup_hook_type prev_shmem_startup_hook = NULL;
 static ProcessUtility_hook_type prev_ProcessUtility = NULL;
 static ExecutorStart_hook_type prev_ExecutorStart = NULL;
@@ -166,6 +169,9 @@ PG_FUNCTION_INFO_V1(pg_dbms_errlog_publish_queue);
 extern PGDLLEXPORT Datum pg_dbms_errlog_queue_size(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(pg_dbms_errlog_queue_size);
 
+#if PG_VERSION_NUM >= 150000
+static void pel_shmem_request(void);
+#endif
 static void pel_shmem_startup(void);
 static void pel_ProcessUtility(PEL_PROCESSUTILITY_PROTO);
 static void pel_ExecutorStart(QueryDesc *queryDesc, int eflags);
@@ -407,16 +413,25 @@ _PG_init(void)
 
 	EmitWarningsOnPlaceholders("pg_dbms_errlog");
 
+#if PG_VERSION_NUM < 150000
 	/*
 	 * Request additional shared resources.  (These are no-ops if we're not in
 	 * the postmaster process.)  We'll allocate or attach to the shared
 	 * resources in pel_shmem_startup().
+	 *
+	 * If you change code here, don't forget to also report the modifications
+	 * in pel_shmem_request() for pg15 and later.
 	 */
 	RequestAddinShmemSpace(pel_memsize());
 	RequestNamedLWLockTranche(PEL_TRANCHE_NAME, 1);
+#endif
 
 
 	/* Install hooks */
+#if PG_VERSION_NUM >= 150000
+	prev_shmem_request_hook = shmem_request_hook;
+	shmem_request_hook = pel_shmem_request;
+#endif
 	prev_shmem_startup_hook = shmem_startup_hook;
 	shmem_startup_hook = pel_shmem_startup;
 	prev_ProcessUtility = ProcessUtility_hook;
@@ -471,6 +486,22 @@ pg_dbms_errlog_queue_size(PG_FUNCTION_ARGS)
 	else
 		PG_RETURN_INT32(num);
 }
+
+#if PG_VERSION_NUM >= 150000
+static void
+pel_shmem_request(void)
+{
+	if (prev_shmem_request_hook)
+		prev_shmem_request_hook();
+
+	/*
+	 * If you change code here, don't forget to also report the modifications in
+	 * _PG_init() for pg14 and below.
+	 */
+	RequestAddinShmemSpace(pel_memsize());
+	RequestNamedLWLockTranche(PEL_TRANCHE_NAME, 1);
+}
+#endif
 
 static void
 pel_shmem_startup(void)

--- a/pg_dbms_errlog.c
+++ b/pg_dbms_errlog.c
@@ -65,7 +65,14 @@
 #endif
 
 /* Define ProcessUtility hook proto/parameters following the PostgreSQL version */
-#if PG_VERSION_NUM >= 130000
+#if PG_VERSION_NUM >= 140000
+#define PEL_PROCESSUTILITY_PROTO PlannedStmt *pstmt, const char *queryString, \
+					bool readOnlyTree, \
+					ProcessUtilityContext context, ParamListInfo params, \
+					QueryEnvironment *queryEnv, DestReceiver *dest, \
+					QueryCompletion *qc
+#define PEL_PROCESSUTILITY_ARGS pstmt, queryString, readOnlyTree, context, params, queryEnv, dest, qc
+#elif PG_VERSION_NUM >= 130000
 #define PEL_PROCESSUTILITY_PROTO PlannedStmt *pstmt, const char *queryString, \
 					ProcessUtilityContext context, ParamListInfo params, \
 					QueryEnvironment *queryEnv, DestReceiver *dest, \


### PR DESCRIPTION
The regression tests were broken since the WARNING format change in 0b47f9fa, fixed and slightly improve the message.

Fix pg14 compatibility with the new "readOnlyTree" parameter aded to the process utility hook.

Remove _PG_fini() entirely.  This function hasn't been called in a very long time (since 602a9ef5a7c in 2009) so it doesn't seem worth bothering defining and maintaining it for older major versions now that it's officially removed upstream.

Fix regression tests for pg15.  Since upstream commit b073c3ccd06e4cb845e121387a43faa8c68a7b62, PUBLIC doesn't  have CREATE privilege on the public schema by default.

Finally, fix compatibility with pg15 new shmem_request_hook.