### PR TITLE
Add missing PGDLLEXPORT markings.

### DIFF
--- a/include/pel_worker.h
+++ b/include/pel_worker.h
@@ -17,7 +17,7 @@
 #include "postgres.h"
 
 #if PG_VERSION_NUM >= 100000
-void pel_worker_main(Datum main_arg) pg_attribute_noreturn();
-void pel_dynworker_main(Datum main_arg);
+PGDLLEXPORT void pel_worker_main(Datum main_arg) pg_attribute_noreturn();
+PGDLLEXPORT void pel_dynworker_main(Datum main_arg);
 #endif			/* pg10 */
 #endif			/* _PEL_WORKER_H */


### PR DESCRIPTION
After upstream commit 089480c07, it's necessary for background worker entry
points to be marked PGDLLEXPORT, else they aren't findable by
LookupBackgroundWorkerFunction().

For consistency, add the PGDLLEXPORT for all versions.