### PR TITLE
Fix build failures against PostgreSQL 19

### DIFF
--- a/include/pel_worker.h
+++ b/include/pel_worker.h
@@ -16,13 +16,13 @@
 
 #include "postgres.h"
 
-#if (PG_VERSION_NUM >= 180000)
-PGDLLEXPORT pg_noreturn void pel_worker_main(Datum main_arg);
-PGDLLEXPORT void pel_dynworker_main(Datum main_arg);
-#else
 #if PG_VERSION_NUM >= 100000
-PGDLLEXPORT void pel_worker_main(Datum main_arg) pg_attribute_noreturn();
+/*
+ * pg_attribute_noreturn() was removed in PG19; pg_noreturn (C23 prefix form)
+ * cannot be combined with PGDLLEXPORT.  Use __attribute__((noreturn)) as a
+ * portable suffix that works on GCC/Clang across all supported versions.
+ */
+PGDLLEXPORT void pel_worker_main(Datum main_arg) __attribute__((noreturn));
 PGDLLEXPORT void pel_dynworker_main(Datum main_arg);
 #endif			/* pg10 */
-#endif			/* pg18 */
 #endif			/* _PEL_WORKER_H */

--- a/pg_dbms_errlog.c
+++ b/pg_dbms_errlog.c
@@ -142,25 +142,24 @@ static const struct config_enum_entry pel_sync_options[] =
 #define PEL_SYNC_ON_XACT()	(pel_synchronous == PEL_SYNC_XACT || \
 		(pel_synchronous == PEL_SYNC_QUERY && IsTransactionBlock()))
 bool pel_debug = false;
-bool pel_done = false;
-bool pel_enabled = false;
+static bool pel_done = false;
+static bool pel_enabled = false;
 int pel_frequency = 60;
 int pel_max_workers = 1;
 int  pel_reject_limit = -1;
-char *query_tag = NULL;
-int pel_synchronous = PEL_SYNC_XACT;
-bool pel_no_client_error = true;
+static char *query_tag = NULL;
+static int pel_synchronous = PEL_SYNC_XACT;
+static bool pel_no_client_error = true;
 
 /* global variable used to store DML table name */
-char *current_dml_table = NULL;
-char current_dml_kind = '\0';
-char *current_bind_parameters = NULL;
+static char current_dml_kind = '\0';
+static char *current_bind_parameters = NULL;
 
 /* Current nesting depth of ExecutorRun calls */
 static int	exec_nested_level = 0;
 
 /* cache to store query of prepared stamement */
-struct HTAB *PreparedCache = NULL;
+static struct HTAB *PreparedCache = NULL;
 
 /* Functions declaration */
 void        _PG_init(void);


### PR DESCRIPTION
* include/pel_worker.h: Replace broken version-split noreturn declarations with a single __attribute__((noreturn)) suffix form valid for PG 10–19.

  The PG 18 branch introduced: PGDLLEXPORT pg_noreturn void pel_worker_main(Datum main_arg); where pg_noreturn is the C23 [[noreturn]] keyword.  This failed on PG 19 because GCC in C23 mode does not allow a standard [[noreturn]] attribute to appear between a __attribute__((visibility)) specifier and the return type (the first build log showed: "error: expected identifier or '(' before 'void'").

  The PG 10–17 branch used pg_attribute_noreturn() as a suffix, which was just a wrapper around __attribute__((noreturn)).  That macro was removed entirely in PG 19 (the second build log showed: "error: expected declaration specifiers before 'pg_attribute_noreturn'"), so that branch cannot serve as a fallback either.

  The fix: use __attribute__((noreturn)) directly as a suffix for all PG versions.  This is valid GCC/Clang syntax across PG 10–19, does not conflict with PGDLLEXPORT placement, and requires no version guard.  The redundant PG18+ / else split is removed entirely.

* pg_dbms_errlog.c: Add 'static' to file-local global variables and remove one unused variable to fix -Wmissing-variable-declarations and -Wunused-variable errors promoted in PG 19 builds.

  PostgreSQL 19 enables -Wmissing-variable-declarations (and -Wunused-variable is always present) and promotes both to errors for in-tree extension builds.

  - pel_done, pel_enabled, query_tag, pel_synchronous, pel_no_client_error, current_dml_kind, current_bind_parameters, PreparedCache: none of these are referenced outside pg_dbms_errlog.c, so they become static.

  - current_dml_table: declared but never referenced anywhere in the codebase; removed entirely.

  The four GUC variables shared with other translation units (pel_debug,
  pel_frequency, pel_max_workers, pel_reject_limit) already carry extern
  declarations in include/pg_dbms_errlog.h and are left unchanged.

Coded by Claude, tested by me.