### PR TITLE
Fix crash in dynamic bgworker:

### DIFF
--- a/pel_worker.c
+++ b/pel_worker.c
@@ -403,12 +403,13 @@ pel_dynworker_main(Datum main_arg)
 		Oid new_dbid;
 		int rc;
 
+		SetCurrentStatementStartTimestamp();
+		StartTransactionCommand();
+
 		rc = SPI_connect();
 		if (rc != SPI_OK_CONNECT)
 			ereport(WARNING, (errmsg("Can not connect to SPI manager.")));
 
-		StartTransactionCommand();
-		SetCurrentStatementStartTimestamp();
 		PushActiveSnapshot(GetTransactionSnapshot());
 
 		for(i = 0; i < entry->num_errors; i++)


### PR DESCRIPTION
This fixes crash that I noticed while running regression tests:,
  Assert("context != CurrentMemoryContext")
  in mcxt.c, MemoryContextDelete(), called from SPI_finish(). In
  pel_dynworker_main()'s processing loop, SPI_connect() was called
  before StartTransactionCommand(), the reverse of the documented
  PostgreSQL bgworker+SPI pattern (StartTransactionCommand() ->
  SPI_connect() -> PushActiveSnapshot(), as in src/test/modules/
  worker_spi/worker_spi.c). Connecting to SPI outside of an active
  transaction leaves its procedure memory context parented off a
  context unrelated to the transaction that follows, so by the time
  SPI_finish() runs, CurrentMemoryContext no longer relates to that
  context the way SPI_finish() expects, and the cleanup assert fires.
  Fix: call SetCurrentStatementStartTimestamp() and
  StartTransactionCommand() before SPI_connect(), matching the
  canonical order.

Coded by Claude, tested by me.